### PR TITLE
# Refresh Python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,14 @@ matrix:
     - python: 3.7
     - python: 3.8
     - python: 3.9-dev
+      env: RUN_MYPY=false
 
 install:
   - pip install .[dev]
 
 script:
   - py.test
-  - mypy glucometerutils
+  - if [[ $RUN_MYPY != false ]]; then mypy glucometerutils; fi
   - python setup.py bdist_wheel
   - pip install ./dist/glucometerutils-*.whl
   - if [[ $PRE_COMMIT ]]; then pre-commit install; pre-commit run --all-files; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ matrix:
     - python: 3.6
       env: PRE_COMMIT=true
     - python: 3.7
-    - python: 3.8-dev
+    - python: 3.8
+    - python: 3.9-dev
 
 install:
   - pip install .[dev]


### PR DESCRIPTION
## Refresh Python versions.

 - 3.8 is now stable.
 - 3.9 is now the next release.

## Exclude mypy from Python 3.9

It looks like subscripts (Dict[Text]) don't work correctly with the current 3.9 dev, so ignore mypy on it right now.
