### PR TITLE
## Make HID support a "session" class rather than a base class.

### DIFF
--- a/glucometerutils/drivers/contourusb.py
+++ b/glucometerutils/drivers/contourusb.py
@@ -21,7 +21,7 @@ http://protocols.ascensia.com/Programming-Guide.aspx
 import datetime
 
 from glucometerutils import common
-from glucometerutils.support import contourusb, driver_base
+from glucometerutils.support import contourusb
 
 
 def _extract_timestamp(parsed_record, prefix=""):
@@ -41,11 +41,11 @@ def _extract_timestamp(parsed_record, prefix=""):
     )
 
 
-class Device(contourusb.ContourHidDevice, driver_base.GlucometerDriver):
+class Device(contourusb.ContourHidDevice):
     """Glucometer driver for FreeStyle Libre devices."""
 
-    USB_VENDOR_ID = 0x1A79  # type: int  # Bayer Health Care LLC Contour
-    USB_PRODUCT_ID = 0x6002  # type: int
+    def __init__(self, device):
+        self._hid_session = contourusb.ContourHidSession((0x1A79, 0x6002), device)
 
     def get_meter_info(self):
         self._get_info_record()

--- a/glucometerutils/drivers/fsinsulinx.py
+++ b/glucometerutils/drivers/fsinsulinx.py
@@ -51,7 +51,8 @@ _InsulinxReading = collections.namedtuple(
 class Device(freestyle.FreeStyleHidDevice):
     """Glucometer driver for FreeStyle InsuLinux devices."""
 
-    USB_PRODUCT_ID = 0x3460
+    def __init__(self, device_path):
+        super().__init__(0x3460, device_path)
 
     def get_meter_info(self):
         """Return the device information in structured form."""
@@ -68,7 +69,7 @@ class Device(freestyle.FreeStyleHidDevice):
 
     def get_readings(self):
         """Iterate through the reading records in the device."""
-        for record in self._get_multirecord(b"$result?"):
+        for record in self._session.query_multirecord(b"$result?"):
             if not record or record[0] != _TYPE_GLUCOSE_READING:
                 continue
 

--- a/glucometerutils/drivers/fsprecisionneo.py
+++ b/glucometerutils/drivers/fsprecisionneo.py
@@ -56,7 +56,8 @@ _NeoReading = collections.namedtuple(
 class Device(freestyle.FreeStyleHidDevice):
     """Glucometer driver for FreeStyle Precision Neo devices."""
 
-    USB_PRODUCT_ID = 0x3850
+    def __init__(self, device_path):
+        super().__init__(0x3850, device_path)
 
     def get_meter_info(self):
         """Return the device information in structured form."""
@@ -74,7 +75,7 @@ class Device(freestyle.FreeStyleHidDevice):
 
     def get_readings(self):
         """Iterate through the reading records in the device."""
-        for record in self._get_multirecord(b"$result?"):
+        for record in self._session.query_multirecord(b"$result?"):
             cls = None
             if record and record[0] == _TYPE_GLUCOSE_READING:
                 cls = common.GlucoseReading

--- a/glucometerutils/support/driver_base.py
+++ b/glucometerutils/support/driver_base.py
@@ -1,8 +1,13 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import Optional, Text
 
 
 class GlucometerDriver(ABC):
+    def __init__(self, device_path):
+        # type: (Optional[Text]) -> None
+        pass
+
     def connect(self):
         pass
 

--- a/reversing_tools/abbott/freestyle_hid_console.py
+++ b/reversing_tools/abbott/freestyle_hid_console.py
@@ -45,11 +45,11 @@ def main():
 
     logging.basicConfig(level=args.vlog)
 
-    device = freestyle.FreeStyleHidDevice(args.device)
-    device.TEXT_CMD = args.text_cmd_type
-    device.TEXT_REPLY_CMD = args.text_reply_type
+    session = freestyle.FreeStyleHidSession(
+        None, args.device, args.text_cmd_type, args.text_reply_type
+    )
 
-    device.connect()
+    session.connect()
 
     while True:
         if sys.stdin.isatty():
@@ -59,7 +59,7 @@ def main():
             print(f">>> {command}")
 
         try:
-            print(device._send_text_command(bytes(command, "ascii")))
+            print(session.send_text_command(bytes(command, "ascii")))
         except exceptions.InvalidResponse as error:
             print(f"! {error}")
 


### PR DESCRIPTION
This in turn allows wrapping the FreeStyle access in its own session class,
which the freestyle_hid_console can use without dirty tricks, and without
triggering the now-abstract class.