### PR TITLE
Pull request for master

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,4 @@
+; SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
 ; SPDX-License-Identifier: MIT
 ((nil . ((fill-column . 88)
 	 (whitespace-line-column . 88)))

--- a/glucometer.py
+++ b/glucometer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- python -*-
 #
+# SPDX-FileCopyrightText: © 2013 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 
 from glucometerutils import glucometer

--- a/glucometerutils/common.py
+++ b/glucometerutils/common.py
@@ -6,7 +6,7 @@
 import datetime
 import enum
 import textwrap
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Union
 
 import attr
 
@@ -91,6 +91,10 @@ class KetoneReading:
     timestamp: datetime.datetime
     value: float
     comment: str = ""
+    measure_method: MeasurementMethod = attr.ib(
+        default=MeasurementMethod.BLOOD_SAMPLE,
+        validator=attr.validators.in_({MeasurementMethod.BLOOD_SAMPLE}),
+    )
     extra_data: Dict[str, Any] = attr.Factory(dict)
 
     def as_csv(self, unit: Unit) -> str:
@@ -100,7 +104,7 @@ class KetoneReading:
         return '"%s","%.2f","%s","%s"' % (
             self.timestamp,
             self.value,
-            MeasurementMethod.BLOOD_SAMPLE.value,
+            self.measure_method.value,
             self.comment,
         )
 
@@ -121,6 +125,9 @@ class TimeAdjustment:
             self.measure_method.value,
             self.old_timestamp,
         )
+
+
+AnyReading = Union[GlucoseReading, KetoneReading, TimeAdjustment]
 
 
 @attr.s(auto_attribs=True)

--- a/glucometerutils/common.py
+++ b/glucometerutils/common.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2013 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Common routines for data in glucometers."""
 

--- a/glucometerutils/common.py
+++ b/glucometerutils/common.py
@@ -6,7 +6,7 @@
 import datetime
 import enum
 import textwrap
-from typing import Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 import attr
 
@@ -30,8 +30,7 @@ class MeasurementMethod(enum.Enum):
     TIME = "time"
 
 
-def convert_glucose_unit(value, from_unit, to_unit):
-    # type: (float, Unit, Unit) -> float
+def convert_glucose_unit(value: float, from_unit: Unit, to_unit: Unit) -> float:
     """Convert the given value of glucose level between units.
 
     Args:
@@ -54,31 +53,28 @@ def convert_glucose_unit(value, from_unit, to_unit):
     return round(value * 18.0, 0)
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class GlucoseReading:
 
-    timestamp = attr.ib(type=datetime.datetime)
-    value = attr.ib(type=float)
-    meal = attr.ib(default=Meal.NONE, validator=attr.validators.in_(Meal), type=Meal)
-    comment = attr.ib(default="", type=str)
-    measure_method = attr.ib(
+    timestamp: datetime.datetime
+    value: float
+    meal: Meal = attr.ib(default=Meal.NONE, validator=attr.validators.in_(Meal))
+    comment: str = ""
+    measure_method: MeasurementMethod = attr.ib(
         default=MeasurementMethod.BLOOD_SAMPLE,
         validator=attr.validators.in_(MeasurementMethod),
-        type=MeasurementMethod,
     )
-    extra_data = attr.ib(factory=dict)
+    extra_data: Dict[str, Any] = attr.Factory(dict)
 
-    def get_value_as(self, to_unit):
-        # type: (Unit) -> float
+    def get_value_as(self, to_unit: Unit) -> float:
         """Returns the reading value as the given unit.
 
         Args:
-          to_unit: (Unit) The unit to return the value to.
+          to_unit: The unit to return the value to.
         """
         return convert_glucose_unit(self.value, Unit.MG_DL, to_unit)
 
-    def as_csv(self, unit):
-        # type: (Unit) -> str
+    def as_csv(self, unit: Unit) -> str:
         """Returns the reading as a formatted comma-separated value string."""
         return '"%s","%.2f","%s","%s","%s"' % (
             self.timestamp,
@@ -89,15 +85,15 @@ class GlucoseReading:
         )
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class KetoneReading:
 
-    timestamp = attr.ib(type=datetime.datetime)
-    value = attr.ib(type=float)
-    comment = attr.ib(default="", type=str)
-    extra_data = attr.ib(factory=dict)
+    timestamp: datetime.datetime
+    value: float
+    comment: str = ""
+    extra_data: Dict[str, Any] = attr.Factory(dict)
 
-    def as_csv(self, unit):
+    def as_csv(self, unit: Unit) -> str:
         """Returns the reading as a formatted comma-separated value string."""
         del unit  # Unused for Ketone readings.
 
@@ -109,16 +105,16 @@ class KetoneReading:
         )
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class TimeAdjustment:
-    timestamp = attr.ib()  # type: datetime.datetime
-    old_timestamp = attr.ib()  # type: datetime.datetime
-    measure_method = attr.ib(
+    timestamp: datetime.datetime
+    old_timestamp: datetime.datetime
+    measure_method: MeasurementMethod = attr.ib(
         default=MeasurementMethod.TIME, validator=attr.validators.in_(MeasurementMethod)
-    )  # type: MeasurementMethod
-    extra_data = attr.ib(factory=dict)
+    )
+    extra_data: Dict[str, Any] = attr.Factory(dict)
 
-    def as_csv(self, unit):
+    def as_csv(self, unit: Unit) -> str:
         del unit
         return '"%s","","%s","%s"' % (
             self.timestamp,
@@ -127,7 +123,7 @@ class TimeAdjustment:
         )
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class MeterInfo:
     """General information about the meter.
 
@@ -140,15 +136,13 @@ class MeterInfo:
       native_unit: One of the Unit values to identify the meter native unit.
     """
 
-    model = attr.ib(type=str)
-    serial_number = attr.ib(default="N/A", type=str)
-    version_info = attr.ib(default=(), type=Sequence[str])
-    native_unit = attr.ib(
-        default=Unit.MG_DL, validator=attr.validators.in_(Unit), type=Unit
-    )
-    patient_name = attr.ib(default=None, type=Optional[str])
+    model: str
+    serial_number: str = "N/A"
+    version_info: Sequence[str] = ()
+    native_unit: Unit = attr.ib(default=Unit.MG_DL, validator=attr.validators.in_(Unit))
+    patient_name: Optional[str] = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         version_information_string = "N/A"
         if self.version_info:
             version_information_string = "\n                ".join(

--- a/glucometerutils/drivers/accuchek_reports.py
+++ b/glucometerutils/drivers/accuchek_reports.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2016 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for Accu-Chek Mobile devices with reports mode.
 

--- a/glucometerutils/drivers/contourusb.py
+++ b/glucometerutils/drivers/contourusb.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2019 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for ContourUSB devices.
 

--- a/glucometerutils/drivers/contourusb.py
+++ b/glucometerutils/drivers/contourusb.py
@@ -19,12 +19,13 @@ http://protocols.ascensia.com/Programming-Guide.aspx
 """
 
 import datetime
+from typing import Dict, Generator, NoReturn, Optional
 
 from glucometerutils import common
 from glucometerutils.support import contourusb
 
 
-def _extract_timestamp(parsed_record, prefix=""):
+def _extract_timestamp(parsed_record: Dict[str, str]):
     """Extract the timestamp from a parsed record.
 
     This leverages the fact that all the reading records have the same base structure.
@@ -42,12 +43,12 @@ def _extract_timestamp(parsed_record, prefix=""):
 
 
 class Device(contourusb.ContourHidDevice):
-    """Glucometer driver for FreeStyle Libre devices."""
+    """Glucometer driver for Contour devices."""
 
-    def __init__(self, device):
-        self._hid_session = contourusb.ContourHidSession((0x1A79, 0x6002), device)
+    def __init__(self, device: Optional[str]) -> None:
+        super().__init__((0x1A79, 0x6002), device)
 
-    def get_meter_info(self):
+    def get_meter_info(self) -> common.MeterInfo:
         self._get_info_record()
         return common.MeterInfo(
             "Contour USB",
@@ -56,13 +57,13 @@ class Device(contourusb.ContourHidDevice):
             native_unit=self.get_glucose_unit(),
         )
 
-    def get_glucose_unit(self):  # pylint: disable=no-self-use
+    def get_glucose_unit(self) -> common.Unit:
         if self._get_glucose_unit() == "0":
             return common.Unit.MG_DL
         else:
             return common.Unit.MMOL_L
 
-    def get_readings(self):
+    def get_readings(self) -> Generator[common.AnyReading, None, None]:
         """
         Get reading dump from download data mode(all readings stored)
         This meter supports only blood samples
@@ -75,11 +76,11 @@ class Device(contourusb.ContourHidDevice):
                 measure_method=common.MeasurementMethod.BLOOD_SAMPLE,
             )
 
-    def get_serial_number(self):
+    def get_serial_number(self) -> NoReturn:
         raise NotImplementedError
 
-    def _set_device_datetime(self, date):
+    def _set_device_datetime(self, date: datetime.datetime) -> NoReturn:
         raise NotImplementedError
 
-    def zero_log(self):
+    def zero_log(self) -> NoReturn:
         raise NotImplementedError

--- a/glucometerutils/drivers/fsinsulinx.py
+++ b/glucometerutils/drivers/fsinsulinx.py
@@ -18,6 +18,7 @@ Xavier Claessens.
 
 import collections
 import datetime
+from typing import Generator, NoReturn, Optional
 
 from glucometerutils import common
 from glucometerutils.support import freestyle
@@ -51,10 +52,10 @@ _InsulinxReading = collections.namedtuple(
 class Device(freestyle.FreeStyleHidDevice):
     """Glucometer driver for FreeStyle InsuLinux devices."""
 
-    def __init__(self, device_path):
+    def __init__(self, device_path: Optional[str]) -> None:
         super().__init__(0x3460, device_path)
 
-    def get_meter_info(self):
+    def get_meter_info(self) -> common.MeterInfo:
         """Return the device information in structured form."""
         return common.MeterInfo(
             "FreeStyle InsuLinx",
@@ -63,11 +64,11 @@ class Device(freestyle.FreeStyleHidDevice):
             native_unit=self.get_glucose_unit(),
         )
 
-    def get_glucose_unit(self):  # pylint: disable=no-self-use
+    def get_glucose_unit(self) -> common.Unit:  # pylint: disable=no-self-use
         """Returns the glucose unit of the device."""
         return common.Unit.MG_DL
 
-    def get_readings(self):
+    def get_readings(self) -> Generator[common.AnyReading, None, None]:
         """Iterate through the reading records in the device."""
         for record in self._session.query_multirecord(b"$result?"):
             if not record or record[0] != _TYPE_GLUCOSE_READING:
@@ -87,5 +88,5 @@ class Device(freestyle.FreeStyleHidDevice):
 
             yield common.GlucoseReading(timestamp, raw_reading.value)
 
-    def zero_log(self):
+    def zero_log(self) -> NoReturn:
         raise NotImplementedError

--- a/glucometerutils/drivers/fsinsulinx.py
+++ b/glucometerutils/drivers/fsinsulinx.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for FreeStyle InsuLinx devices.
 

--- a/glucometerutils/drivers/fslibre.py
+++ b/glucometerutils/drivers/fslibre.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for FreeStyle Libre devices.
 

--- a/glucometerutils/drivers/fsoptium.py
+++ b/glucometerutils/drivers/fsoptium.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for FreeStyle Optium devices.
 

--- a/glucometerutils/drivers/fsprecisionneo.py
+++ b/glucometerutils/drivers/fsprecisionneo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for FreeStyle Precision Neo devices.
 

--- a/glucometerutils/drivers/otultra2.py
+++ b/glucometerutils/drivers/otultra2.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2013 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for LifeScan OneTouch Ultra 2 devices.
 

--- a/glucometerutils/drivers/otultraeasy.py
+++ b/glucometerutils/drivers/otultraeasy.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2014 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for LifeScan OneTouch Ultra Easy devices.
 

--- a/glucometerutils/drivers/otverio2015.py
+++ b/glucometerutils/drivers/otverio2015.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2016 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for LifeScan OneTouch Verio (2015) and Select Plus devices.
 

--- a/glucometerutils/drivers/otverioiq.py
+++ b/glucometerutils/drivers/otverioiq.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2018 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for LifeScan OneTouch Verio IQ devices.
 

--- a/glucometerutils/drivers/sdcodefree.py
+++ b/glucometerutils/drivers/sdcodefree.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2016 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for SD CodeFree devices by SD Biosensor.
 

--- a/glucometerutils/drivers/td4277.py
+++ b/glucometerutils/drivers/td4277.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2019 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Driver for TaiDoc TD-4277 devices.
 

--- a/glucometerutils/drivers/tests/test_fsoptium.py
+++ b/glucometerutils/drivers/tests/test_fsoptium.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2019 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Tests for the FreeStyle Optium driver."""
 

--- a/glucometerutils/drivers/tests/test_otultra2.py
+++ b/glucometerutils/drivers/tests/test_otultra2.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2013 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Tests for the LifeScan OneTouch Ultra 2 driver."""
 

--- a/glucometerutils/drivers/tests/test_otultraeasy.py
+++ b/glucometerutils/drivers/tests/test_otultraeasy.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2014 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Tests for the LifeScan OneTouch Ultra Easy driver."""
 

--- a/glucometerutils/drivers/tests/test_td4277.py
+++ b/glucometerutils/drivers/tests/test_td4277.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2019 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Tests for the TD-4277 driver."""
 

--- a/glucometerutils/exceptions.py
+++ b/glucometerutils/exceptions.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2013 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Common exceptions for glucometerutils."""
 

--- a/glucometerutils/exceptions.py
+++ b/glucometerutils/exceptions.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 """Common exceptions for glucometerutils."""
 
+from typing import Any, Optional
+
 
 class Error(Exception):
     """Base class for the errors."""
@@ -15,42 +17,43 @@ class CommandLineError(Error):
 class ConnectionFailed(Error):
     """It was not possible to connect to the meter."""
 
-    def __init__(self, message="Unable to connect to the meter."):
-        super(ConnectionFailed, self).__init__(message)
+    def __init__(self, message: str = "Unable to connect to the meter.") -> None:
+        super().__init__(message)
 
 
 class CommandError(Error):
     """It was not possible to send a command to the device."""
 
-    def __init__(self, message="Unable to send command to device."):
-        super(CommandError, self).__init__(message)
+    def __init__(self, message: str = "Unable to send command to device.") -> None:
+        super().__init__(message)
 
 
 class InvalidResponse(Error):
     """The response received from the meter was not understood"""
 
-    def __init__(self, response):
-        super(InvalidResponse, self).__init__(f"Invalid response received:\n{response}")
+    def __init__(self, response: str) -> None:
+        super().__init__(f"Invalid response received:\n{response}")
 
 
 class InvalidChecksum(InvalidResponse):
-    def __init__(self, wire, calculated):
-        super(InvalidChecksum, self).__init__(
-            f"Response checksum not matching: {wire:08x} (wire) != {calculated:08x} (calculated)"
-        )
+    def __init__(self, wire: int, calculated: Optional[int]) -> None:
+        if calculated is not None:
+            message = f"Response checksum not matching: {wire:08x} (wire) != {calculated:08x} (calculated)"
+        else:
+            message = f"Unable to calculate checksum. Expected {wire:08x}."
+
+        super().__init__(message)
 
 
 class InvalidGlucoseUnit(Error):
     """Unable to parse the given glucose unit"""
 
-    def __init__(self, unit):
-        super(InvalidGlucoseUnit, self).__init__(
-            f"Invalid glucose unit received:\n{unit}"
-        )
+    def __init__(self, unit: Any) -> None:
+        super().__init__(f"Invalid glucose unit received:\n{unit}")
 
 
 class InvalidDateTime(Error):
     """The device has an invalid date/time setting."""
 
-    def __init__(self):
-        super(InvalidDateTime, self).__init__("Invalid date and time for device")
+    def __init__(self) -> None:
+        super().__init__("Invalid date and time for device")

--- a/glucometerutils/glucometer.py
+++ b/glucometerutils/glucometer.py
@@ -156,7 +156,7 @@ def main():
                     new_date = date_parser.parse(args.set)
                 except ImportError:
                     logging.error(
-                        'Unable to import module "dateutil", ' "please install it."
+                        'Unable to import module "dateutil", please install it.'
                     )
                     return 1
                 except ValueError:

--- a/glucometerutils/glucometer.py
+++ b/glucometerutils/glucometer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2013 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Utility to manage glucometers' data."""
 

--- a/glucometerutils/glucometer.py
+++ b/glucometerutils/glucometer.py
@@ -14,8 +14,8 @@ from glucometerutils import common, exceptions
 
 
 def main():
-    if sys.version_info < (3, 5):
-        raise Exception("Unsupported Python version, please use at least Python 3.5")
+    if sys.version_info < (3, 7):
+        raise Exception("Unsupported Python version, please use at least Python 3.7")
 
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="action")

--- a/glucometerutils/support/construct_extras.py
+++ b/glucometerutils/support/construct_extras.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2018 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Extra classes for Construct."""
 

--- a/glucometerutils/support/construct_extras.py
+++ b/glucometerutils/support/construct_extras.py
@@ -18,15 +18,15 @@ class Timestamp(construct.Adapter):
 
     __slots__ = ["epoch"]
 
-    def __init__(self, subcon, epoch=0):
+    def __init__(self, subcon, epoch: int = 0) -> None:
         super(Timestamp, self).__init__(subcon)
         self.epoch = epoch
 
-    def _encode(self, obj, context, path):
+    def _encode(self, obj: datetime.datetime, context, path) -> int:
         assert isinstance(obj, datetime.datetime)
         epoch_date = datetime.datetime.utcfromtimestamp(self.epoch)
         delta = obj - epoch_date
         return int(delta.total_seconds())
 
-    def _decode(self, obj, context, path):
+    def _decode(self, obj: int, context, path) -> datetime.datetime:
         return datetime.datetime.utcfromtimestamp(obj + self.epoch)

--- a/glucometerutils/support/contourusb.py
+++ b/glucometerutils/support/contourusb.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2019 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Common routines to implement the ContourUSB common protocol.
 

--- a/glucometerutils/support/driver_base.py
+++ b/glucometerutils/support/driver_base.py
@@ -1,38 +1,45 @@
-from abc import ABC, abstractmethod
-from datetime import datetime
-from typing import Optional, Text
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: MIT
+
+import abc
+import datetime
+from typing import Generator, Optional, Text
+
+from glucometerutils import common
 
 
-class GlucometerDriver(ABC):
-    def __init__(self, device_path):
-        # type: (Optional[Text]) -> None
+class GlucometerDriver(abc.ABC):
+    def __init__(self, device_path: Optional[Text]) -> None:
         pass
 
-    def connect(self):
+    def connect(self) -> None:
         pass
 
-    def disconnect(self):
+    def disconnect(self) -> None:
         pass
 
-    @abstractmethod
-    def get_meter_info(self):
+    @abc.abstractmethod
+    def get_meter_info(self) -> common.MeterInfo:
         """Return the device information in structured form."""
         pass
 
-    @abstractmethod
-    def get_serial_number(self):
+    @abc.abstractmethod
+    def get_serial_number(self) -> str:
         pass
 
-    @abstractmethod
-    def get_glucose_unit(self):
+    @abc.abstractmethod
+    def get_glucose_unit(self) -> common.Unit:
         """Returns the glucose unit of the device."""
         pass
 
-    @abstractmethod
-    def get_datetime(self):
+    @abc.abstractmethod
+    def get_datetime(self) -> datetime.datetime:
         pass
 
-    def set_datetime(self, date=None):
+    def set_datetime(
+        self, date: Optional[datetime.datetime] = None
+    ) -> datetime.datetime:
         """Sets the date and time of the glucometer.
 
         Args:
@@ -43,17 +50,17 @@ class GlucometerDriver(ABC):
           A datetime object built according to the returned response.
         """
         if not date:
-            date = datetime.now()
+            date = datetime.datetime.now()
         return self._set_device_datetime(date)
 
-    @abstractmethod
-    def _set_device_datetime(self, date):
+    @abc.abstractmethod
+    def _set_device_datetime(self, date: datetime.datetime) -> datetime.datetime:
         pass
 
-    @abstractmethod
-    def zero_log(self):
+    @abc.abstractmethod
+    def zero_log(self) -> None:
         pass
 
-    @abstractmethod
-    def get_readings(self):
+    @abc.abstractmethod
+    def get_readings(self) -> Generator[common.AnyReading, None, None]:
         pass

--- a/glucometerutils/support/driver_base.py
+++ b/glucometerutils/support/driver_base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2020 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 
 import abc

--- a/glucometerutils/support/freestyle.py
+++ b/glucometerutils/support/freestyle.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Common routines to implement the FreeStyle common protocol.
 

--- a/glucometerutils/support/hiddevice.py
+++ b/glucometerutils/support/hiddevice.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Common routines and base driver class for HID-based meters.
 """

--- a/glucometerutils/support/hiddevice.py
+++ b/glucometerutils/support/hiddevice.py
@@ -6,7 +6,7 @@
 
 import logging
 import os
-from typing import BinaryIO, Optional, Text, Tuple
+from typing import BinaryIO, Optional, Tuple
 
 from glucometerutils import exceptions
 
@@ -18,8 +18,12 @@ class HidSession:
     methods abstracting the HID library.
     """
 
-    def __init__(self, usb_id, device, timeout_ms=0):
-        # type: (Optional[Tuple[int, int]], Optional[Text], int) -> None
+    def __init__(
+        self,
+        usb_id: Optional[Tuple[int, int]],
+        device: Optional[str],
+        timeout_ms: int = 0,
+    ) -> None:
         """Construct a new session object.
 
         Args:
@@ -66,8 +70,7 @@ class HidSession:
                     message=f"Unable to connect to meter: {e}."
                 )
 
-    def write(self, report):
-        # type: (bytes) -> None
+    def write(self, report: bytes) -> None:
         """Writes a report to the HID handle."""
 
         if self.handle_:
@@ -78,8 +81,7 @@ class HidSession:
         if written < 0:
             raise exceptions.CommandError()
 
-    def read(self, size=64):
-        # type: (int) -> bytes
+    def read(self, size: int = 64) -> bytes:
         """Read a report from the HID handle.
 
         This is important as it handles the one incompatible interface between

--- a/glucometerutils/support/lifescan.py
+++ b/glucometerutils/support/lifescan.py
@@ -9,7 +9,7 @@ from glucometerutils import exceptions
 class MissingChecksum(exceptions.InvalidResponse):
     """The response misses the expected 4-digits checksum."""
 
-    def __init__(self, response):
+    def __init__(self, response: str):
         super(MissingChecksum, self).__init__(
             f"Response is missing checksum: {response}"
         )
@@ -18,19 +18,18 @@ class MissingChecksum(exceptions.InvalidResponse):
 class InvalidSerialNumber(exceptions.Error):
     """The serial number is not as expected."""
 
-    def __init__(self, serial_number):
+    def __init__(self, serial_number: str):
         super(InvalidSerialNumber, self).__init__(
             f"Serial number {serial_number} is invalid."
         )
 
 
 class MalformedCommand(exceptions.InvalidResponse):
-    def __init__(self, message):
+    def __init__(self, message: str):
         super(MalformedCommand, self).__init__(f"Malformed command: {message}")
 
 
-def crc_ccitt(data):
-    # type: (bytes) -> int
+def crc_ccitt(data: bytes) -> int:
     """Calculate the CRC-16-CCITT with LifeScan's common seed.
 
     Args:

--- a/glucometerutils/support/lifescan.py
+++ b/glucometerutils/support/lifescan.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Common utility functions for LifeScan meters."""
 

--- a/glucometerutils/support/lifescan_binary_protocol.py
+++ b/glucometerutils/support/lifescan_binary_protocol.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2018 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Support module for the LifeScan binary protocol.
 

--- a/glucometerutils/support/lifescan_binary_protocol.py
+++ b/glucometerutils/support/lifescan_binary_protocol.py
@@ -24,8 +24,9 @@ _LINK_CONTROL = construct.BitStruct(
 )
 
 
-def LifeScanPacket(include_link_control):  # pylint: disable=invalid-name
-    # type: (bool) -> construct.Struct
+def LifeScanPacket(
+    include_link_control: bool,
+) -> construct.Struct:  # pylint: disable=invalid-name
     if include_link_control:
         link_control_construct = _LINK_CONTROL
     else:

--- a/glucometerutils/support/serial.py
+++ b/glucometerutils/support/serial.py
@@ -5,9 +5,10 @@
 """
 
 import logging
-from typing import Optional, Text
+from typing import Optional
 
 import serial
+
 from glucometerutils import exceptions
 
 
@@ -37,13 +38,12 @@ class SerialDevice:
 
     """
 
-    BAUDRATE = None  # type: int
-    DEFAULT_CABLE_ID = None  # type: Text
+    BAUDRATE: Optional[int] = None
+    DEFAULT_CABLE_ID: Optional[str] = None
 
-    TIMEOUT = 1  # type: float
+    TIMEOUT: float = 1
 
-    def __init__(self, device):
-        # type: (Optional[Text]) -> None
+    def __init__(self, device: Optional[str]) -> None:
         assert self.BAUDRATE is not None
 
         if not device and self.DEFAULT_CABLE_ID:

--- a/glucometerutils/support/serial.py
+++ b/glucometerutils/support/serial.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Common routines and base driver class for serial-based meters.
 """

--- a/glucometerutils/support/tests/test_construct_extras.py
+++ b/glucometerutils/support/tests/test_construct_extras.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2018 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Tests for the common routines."""
 

--- a/glucometerutils/support/tests/test_freestyle.py
+++ b/glucometerutils/support/tests/test_freestyle.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2019 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Tests for the common FreeStyle functions.."""
 

--- a/glucometerutils/support/tests/test_lifescan.py
+++ b/glucometerutils/support/tests/test_lifescan.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2013 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Tests for the LifeScan OneTouch Ultra Mini driver."""
 

--- a/glucometerutils/tests/test_common.py
+++ b/glucometerutils/tests/test_common.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2013 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """Tests for the common routines."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,6 @@ multi_line_output = 3
 include_trailing_comma = true
 
 known_first_party = ['glucometerutils']
-known_third_party = ['construct', 'hidapi', 'pyserial', 'pyscsi']
+known_third_party = ['construct', 'hidapi', 'pyscsi', 'serial']
 
 [tool.setuptools_scm]

--- a/reversing_tools/abbott/extract_freestyle.py
+++ b/reversing_tools/abbott/extract_freestyle.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-FileCopyrightText: © 2019 The usbmon-tools Authors; © 2020 The glucometerutils Authors
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/reversing_tools/abbott/freestyle_hid_console.py
+++ b/reversing_tools/abbott/freestyle_hid_console.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2019 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 """CLI tool to send messages through FreeStyle HID protocol."""
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# SPDX-FileCopyrightText: © 2013 The glucometerutils Authors
 # SPDX-License-Identifier: MIT
 
 from setuptools import find_packages, setup

--- a/udev/69-glucometerutils.rules
+++ b/udev/69-glucometerutils.rules
@@ -1,4 +1,6 @@
 # udev rules for glucometer devices using usb/tty/hid interfaces
+# SPDX-FileCopyrightText: © 2017 The glucometerutils Authors
+# SPDX-License-Identifier: MIT
 
 # Installation:
 # - Copy this file to /etc/udev/rules.d/


### PR DESCRIPTION
## Use PEP526 declarations rather than `attr.ib()` calls all over.

This simplifies type annotations a bit, and makes it easier figure out why
attrs is still required (validators).

## Fix typing for contourusb support module.

This replaces the definition of modes with an Enum class, which is more
appropriate, and adds typing throughout the module.

Text is also replaced with str since we don't support Python 2 anyway.

## Combine a strangely-separated string.


## Bring up command line error as we only support Python 3.7+ now.


## The big typing cleanup.

Now that Python 3.7 is the minimum Python version, typing can be done
inline, which makes it easier for mypy to know the files to check.

Indeed, all the files are now typechecked, which uncovered a few minor bugs
and mistakes here and there.

## Add missing SPDX-FileCopyrightText throughout the project.

This is following the advice provided in https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code