### PR TITLE
Update otverio2015 dependencies to include PYSCSI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ it to https://protocols.glucometers.tech/ .
 
 [construct]: https://construct.readthedocs.io/en/latest/
 [pyserial]: https://pythonhosted.org/pyserial/
-[python-scsi]: https://github.com/rosjat/python-scsi
+[python-scsi]: https://pypi.org/project/PYSCSI/
 [hidapi]: https://pypi.python.org/pypi/hidapi
 
 ## Dump format

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
     "fsprecisionneo": ["construct", "hidapi"],
     "otultra2": ["pyserial"],
     "otultraeasy": ["construct", "pyserial"],
-    "otverio2015": ["construct"],
+    "otverio2015": ["construct", "PYSCSI[sgio]>=2.0.1"],
     "otverioiq": ["construct", "pyserial"],
     "sdcodefree": ["construct", "pyserial"],
     "td4277": ["construct", "pyserial", "hidapi"],


### PR DESCRIPTION
Now that PYSCSI v2.0.1 is released, its dependency can be expressed
correctly.

Also link to PyPI rather than Markus's own fork.