### PR TITLE
Make use of modern Python ordered kwargs.

### DIFF
--- a/glucometerutils/drivers/otultraeasy.py
+++ b/glucometerutils/drivers/otultraeasy.py
@@ -40,8 +40,8 @@ _COMMAND_SUCCESS = construct.Const(b"\x05\x06")
 _VERSION_REQUEST = construct.Const(b"\x05\x0d\x02")
 
 _VERSION_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "version" / construct.PascalString(construct.Byte, encoding="ascii"),
+    success=_COMMAND_SUCCESS,
+    version=construct.PascalString(construct.Byte, encoding="ascii"),
 )
 
 _SERIAL_NUMBER_REQUEST = construct.Const(
@@ -49,47 +49,46 @@ _SERIAL_NUMBER_REQUEST = construct.Const(
 )
 
 _SERIAL_NUMBER_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS, "serial_number" / construct.GreedyString(encoding="ascii"),
+    success=_COMMAND_SUCCESS, serial_number=construct.GreedyString(encoding="ascii"),
 )
 
 _DATETIME_REQUEST = construct.Struct(
-    construct.Const(b"\x05\x20"),  # 0x20 is the datetime
-    "request_type" / construct.Enum(construct.Byte, write=0x01, read=0x02),
-    "timestamp"
-    / construct.Default(
+    const=construct.Const(b"\x05\x20"),  # 0x20 is the datetime
+    request_type=construct.Enum(construct.Byte, write=0x01, read=0x02),
+    timestamp=construct.Default(
         construct_extras.Timestamp(construct.Int32ul),  # type: ignore
         datetime.datetime(1970, 1, 1, 0, 0),
     ),
 )
 
 _DATETIME_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "timestamp" / construct_extras.Timestamp(construct.Int32ul),  # type: ignore
+    success=_COMMAND_SUCCESS,
+    timestamp=construct_extras.Timestamp(construct.Int32ul),  # type: ignore
 )
 
 _GLUCOSE_UNIT_REQUEST = construct.Const(b"\x05\x09\x02\x09\x00\x00\x00\x00")
 
 
 _GLUCOSE_UNIT_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "unit" / lifescan_binary_protocol.GLUCOSE_UNIT,
-    construct.Padding(3),
+    success=_COMMAND_SUCCESS,
+    unit=lifescan_binary_protocol.GLUCOSE_UNIT,
+    padding=construct.Padding(3),
 )
 
 _MEMORY_ERASE_REQUEST = construct.Const(b"\x05\x1A")
 
 _READING_COUNT_RESPONSE = construct.Struct(
-    construct.Const(b"\x0f"), "count" / construct.Int16ul,
+    const=construct.Const(b"\x0f"), count=construct.Int16ul,
 )
 
 _READ_RECORD_REQUEST = construct.Struct(
-    construct.Const(b"\x05\x1f"), "record_id" / construct.Int16ul,
+    const=construct.Const(b"\x05\x1f"), record_id=construct.Int16ul,
 )
 
 _READING_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "timestamp" / construct_extras.Timestamp(construct.Int32ul),  # type: ignore
-    "value" / construct.Int32ul,
+    success=_COMMAND_SUCCESS,
+    timestamp=construct_extras.Timestamp(construct.Int32ul),  # type: ignore
+    value=construct.Int32ul,
 )
 
 

--- a/glucometerutils/drivers/otverio2015.py
+++ b/glucometerutils/drivers/otverio2015.py
@@ -45,34 +45,34 @@ _PACKET = construct.Padded(
 _COMMAND_SUCCESS = construct.Const(b"\x03\x06")
 
 _QUERY_REQUEST = construct.Struct(
-    construct.Const(b"\x03\xe6\x02"),
-    "selector" / construct.Enum(construct.Byte, serial=0x00, model=0x01, software=0x02),
+    const=construct.Const(b"\x03\xe6\x02"),
+    selector=construct.Enum(construct.Byte, serial=0x00, model=0x01, software=0x02),
 )
 
 _QUERY_RESPONSE = construct.Struct(
-    construct.Const(b"\x03\x06"), "value" / construct.CString(encoding="utf-16-le"),
+    const=construct.Const(b"\x03\x06"), value=construct.CString(encoding="utf-16-le"),
 )
 
 _READ_PARAMETER_REQUEST = construct.Struct(
-    construct.Const(b"\x03"), "selector" / construct.Enum(construct.Byte, unit=0x04),
+    const=construct.Const(b"\x03"), selector=construct.Enum(construct.Byte, unit=0x04),
 )
 
 _READ_UNIT_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "unit" / lifescan_binary_protocol.GLUCOSE_UNIT,
-    construct.Padding(3),
+    success=_COMMAND_SUCCESS,
+    unit=lifescan_binary_protocol.GLUCOSE_UNIT,
+    padding=construct.Padding(3),
 )
 
 _READ_RTC_REQUEST = construct.Const(b"\x03\x20\x02")
 
 _READ_RTC_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "timestamp" / lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
+    success=_COMMAND_SUCCESS,
+    timestamp=lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
 )
 
 _WRITE_RTC_REQUEST = construct.Struct(
-    construct.Const(b"\x03\x20\x01"),
-    "timestamp" / lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
+    const=construct.Const(b"\x03\x20\x01"),
+    timestamp=lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
 )
 
 _MEMORY_ERASE_REQUEST = construct.Const(b"\x03\x1a")
@@ -80,13 +80,13 @@ _MEMORY_ERASE_REQUEST = construct.Const(b"\x03\x1a")
 _READ_RECORD_COUNT_REQUEST = construct.Const(b"\x03\x27\x00")
 
 _READ_RECORD_COUNT_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS, "count" / construct.Int16ul,
+    success=_COMMAND_SUCCESS, count=construct.Int16ul,
 )
 
 _READ_RECORD_REQUEST = construct.Struct(
-    construct.Const(b"\x03\x31\x02"),
-    "record_id" / construct.Int16ul,
-    construct.Const(b"\x00"),
+    const_1=construct.Const(b"\x03\x31\x02"),
+    record_id=construct.Int16ul,
+    const_2=construct.Const(b"\x00"),
 )
 
 _MEAL_FLAG = {
@@ -96,14 +96,14 @@ _MEAL_FLAG = {
 }
 
 _READ_RECORD_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "inverse_counter" / construct.Int16ul,
-    construct.Padding(1),
-    "lifetime_counter" / construct.Int16ul,
-    "timestamp" / lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
-    "value" / construct.Int16ul,
-    "meal" / construct.Mapping(construct.Byte, _MEAL_FLAG),
-    construct.Padding(4),
+    success=_COMMAND_SUCCESS,
+    inverse_counter=construct.Int16ul,
+    padding_1=construct.Padding(1),
+    lifetime_counter=construct.Int16ul,
+    timestamp=lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
+    value=construct.Int16ul,
+    meal=construct.Mapping(construct.Byte, _MEAL_FLAG),
+    padding_2=construct.Padding(4),
 )
 
 

--- a/glucometerutils/drivers/otverioiq.py
+++ b/glucometerutils/drivers/otverioiq.py
@@ -33,37 +33,37 @@ _COMMAND_SUCCESS = construct.Const(b"\x03\x06")
 _VERSION_REQUEST = construct.Const(b"\x03\x0d\x01")
 
 _VERSION_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "version" / construct.PascalString(construct.Byte, encoding="ascii"),
+    success=_COMMAND_SUCCESS,
+    version=construct.PascalString(construct.Byte, encoding="ascii"),
     # NULL-termination is not included in string length.
-    construct.Const(b"\x00"),
+    const=construct.Const(b"\x00"),
 )
 
 _SERIAL_NUMBER_REQUEST = construct.Const(b"\x03\x0b\x01\x02")
 
 _SERIAL_NUMBER_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS, "serial_number" / construct.CString(encoding="ascii"),
+    success=_COMMAND_SUCCESS, serial_number=construct.CString(encoding="ascii"),
 )
 
 _READ_RTC_REQUEST = construct.Const(b"\x03\x20\x02")
 
 _READ_RTC_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "timestamp" / lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
+    success=_COMMAND_SUCCESS,
+    timestamp=lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
 )
 
 _WRITE_RTC_REQUEST = construct.Struct(
-    construct.Const(b"\x03\x20\x01"),
-    "timestamp" / lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
+    const=construct.Const(b"\x03\x20\x01"),
+    timestamp=lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
 )
 
 _GLUCOSE_UNIT_REQUEST = construct.Const(b"\x03\x09\x02\x02")
 
 
 _GLUCOSE_UNIT_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "unit" / lifescan_binary_protocol.GLUCOSE_UNIT,
-    construct.Padding(3),
+    success=_COMMAND_SUCCESS,
+    unit=lifescan_binary_protocol.GLUCOSE_UNIT,
+    padding=construct.Padding(3),
 )
 
 _MEMORY_ERASE_REQUEST = construct.Const(b"\x03\x1a")
@@ -71,11 +71,11 @@ _MEMORY_ERASE_REQUEST = construct.Const(b"\x03\x1a")
 _READ_RECORD_COUNT_REQUEST = construct.Const(b"\x03\x27\x00")
 
 _READ_RECORD_COUNT_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS, "count" / construct.Int16ul,
+    success=_COMMAND_SUCCESS, count=construct.Int16ul,
 )
 
 _READ_RECORD_REQUEST = construct.Struct(
-    construct.Const(b"\x03\x21"), "record_id" / construct.Int16ul,
+    const=construct.Const(b"\x03\x21"), record_id=construct.Int16ul,
 )
 
 _MEAL_FLAG = {
@@ -85,12 +85,12 @@ _MEAL_FLAG = {
 }
 
 _READING_RESPONSE = construct.Struct(
-    _COMMAND_SUCCESS,
-    "timestamp" / lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
-    "value" / construct.Int16ul,
-    "control_test" / construct.Flag,
-    "meal" / construct.Mapping(construct.Byte, _MEAL_FLAG),
-    construct.Padding(2),  # unknown
+    success=_COMMAND_SUCCESS,
+    timestamp=lifescan_binary_protocol.VERIO_TIMESTAMP,  # type: ignore
+    value=construct.Int16ul,
+    control_test=construct.Flag,
+    meal=construct.Mapping(construct.Byte, _MEAL_FLAG),
+    padding=construct.Padding(2),  # unknown
 )
 
 

--- a/glucometerutils/drivers/sdcodefree.py
+++ b/glucometerutils/drivers/sdcodefree.py
@@ -40,19 +40,18 @@ class Direction(enum.Enum):
 
 
 _PACKET = construct.Struct(
-    "stx" / construct.Const(0x53, construct.Byte),
-    "direction" / construct.Mapping(construct.Byte, {e: e.value for e in Direction}),
-    "length" / construct.Rebuild(construct.Byte, lambda this: len(this.message) + 2),
-    "message" / construct.Bytes(lambda this: this.length - 2),
-    "checksum"
-    / construct.Checksum(construct.Byte, xor_checksum, construct.this.message),
-    "etx" / construct.Const(0xAA, construct.Byte),
+    stx=construct.Const(0x53, construct.Byte),
+    direction=construct.Mapping(construct.Byte, {e: e.value for e in Direction}),
+    length=construct.Rebuild(construct.Byte, lambda this: len(this.message) + 2),
+    message=construct.Bytes(lambda this: this.length - 2),
+    checksum=construct.Checksum(construct.Byte, xor_checksum, construct.this.message),
+    etx=construct.Const(0xAA, construct.Byte),
 )
 
 _FIRST_MESSAGE = construct.Struct(
-    construct.Const(0x30, construct.Byte),
-    "count" / construct.Int16ub,
-    construct.Const(0xAA, construct.Byte)[19],
+    const_1=construct.Const(0x30, construct.Byte),
+    count=construct.Int16ub,
+    const_2=construct.Const(0xAA, construct.Byte)[19],
 )
 
 _CHALLENGE_PACKET_FULL = b"\x53\x20\x04\x10\x30\x20\xAA"
@@ -72,15 +71,15 @@ _MEAL_FLAG = {
 }
 
 _READING = construct.Struct(
-    construct.Byte[2],
-    "year" / construct.Byte,
-    "month" / construct.Byte,
-    "day" / construct.Byte,
-    "hour" / construct.Byte,
-    "minute" / construct.Byte,
-    "value" / construct.Int16ub,
-    "meal" / construct.Mapping(construct.Byte, _MEAL_FLAG),
-    construct.Byte[7],
+    unknown_1=construct.Byte[2],
+    year=construct.Byte,
+    month=construct.Byte,
+    day=construct.Byte,
+    hour=construct.Byte,
+    minute=construct.Byte,
+    value=construct.Int16ub,
+    meal=construct.Mapping(construct.Byte, _MEAL_FLAG),
+    unknown_2=construct.Byte[7],
 )
 
 

--- a/glucometerutils/drivers/td4277.py
+++ b/glucometerutils/drivers/td4277.py
@@ -37,18 +37,19 @@ def byte_checksum(data):
 
 
 _PACKET = construct.Struct(
-    "data"
-    / construct.RawCopy(
+    data=construct.RawCopy(
         construct.Struct(
-            construct.Const(b"\x51"),
-            "command" / construct.Byte,
-            "message" / construct.Bytes(4),
-            "direction"
-            / construct.Mapping(construct.Byte, {e: e.value for e in Direction}),
+            const=construct.Const(b"\x51"),
+            command=construct.Byte,
+            message=construct.Bytes(4),
+            direction=construct.Mapping(
+                construct.Byte, {e: e.value for e in Direction}
+            ),
         ),
     ),
-    "checksum"
-    / construct.Checksum(construct.Byte, byte_checksum, construct.this.data.data),
+    checksum=construct.Checksum(
+        construct.Byte, byte_checksum, construct.this.data.data
+    ),
 )
 
 _EMPTY_MESSAGE = b"\x00\x00\x00\x00"
@@ -68,25 +69,27 @@ _GET_READING_VALUE = 0x26
 _CLEAR_MEMORY = 0x52
 
 _MODEL_STRUCT = construct.Struct(
-    construct.Const(b"\x77\x42"), construct.Byte, construct.Byte,
+    const=construct.Const(b"\x77\x42"),
+    unknown_1=construct.Byte,
+    unknown_2=construct.Byte,
 )
 
 _DATETIME_STRUCT = construct.Struct(
-    "day" / construct.Int16ul, "minute" / construct.Byte, "hour" / construct.Byte,
+    day=construct.Int16ul, minute=construct.Byte, hour=construct.Byte,
 )
 
 _DAY_BITSTRUCT = construct.BitStruct(
-    "year" / construct.BitsInteger(7),
-    "month" / construct.BitsInteger(4),
-    "day" / construct.BitsInteger(5),
+    year=construct.BitsInteger(7),
+    month=construct.BitsInteger(4),
+    day=construct.BitsInteger(5),
 )
 
 _READING_COUNT_STRUCT = construct.Struct(
-    "count" / construct.Int16ul, construct.Int16ul,
+    count=construct.Int16ul, unknown=construct.Int16ul,
 )
 
 _READING_SELECTION_STRUCT = construct.Struct(
-    "record_id" / construct.Int16ul, construct.Const(b"\x00\x00"),
+    record_id=construct.Int16ul, const=construct.Const(b"\x00\x00"),
 )
 
 _MEAL_FLAG = {
@@ -96,9 +99,9 @@ _MEAL_FLAG = {
 }
 
 _READING_VALUE_STRUCT = construct.Struct(
-    "value" / construct.Int16ul,
-    construct.Const(b"\x06"),
-    "meal" / construct.Mapping(construct.Byte, _MEAL_FLAG),
+    value=construct.Int16ul,
+    const=construct.Const(b"\x06"),
+    meal=construct.Mapping(construct.Byte, _MEAL_FLAG),
 )
 
 

--- a/glucometerutils/support/freestyle.py
+++ b/glucometerutils/support/freestyle.py
@@ -62,20 +62,18 @@ _is_encryption_missing_error = _create_matcher(_ENCRYPTION_SETUP_RESPONSE, b"\x1
 _is_encryption_setup_error = _create_matcher(_ENCRYPTION_SETUP_RESPONSE, b"\x14")
 
 _FREESTYLE_MESSAGE = construct.Struct(
-    "hid_report" / construct.Const(0, construct.Byte),
-    "message_type" / construct.Byte,
-    "command"
-    / construct.Padded(
+    hid_report=construct.Const(0, construct.Byte),
+    message_type=construct.Byte,
+    command=construct.Padded(
         63,  # command can only be up to 62 bytes, but one is used for length.
         construct.Prefixed(construct.Byte, construct.GreedyBytes),
     ),
 )
 
 _FREESTYLE_ENCRYPTED_MESSAGE = construct.Struct(
-    "hid_report" / construct.Const(0, construct.Byte),
-    "message_type" / construct.Byte,
-    "command"
-    / construct.Padded(
+    hid_report=construct.Const(0, construct.Byte),
+    message_type=construct.Byte,
+    command=construct.Padded(
         63,  # command can only be up to 62 bytes, but one is used for length.
         construct.GreedyBytes,
     ),

--- a/glucometerutils/support/lifescan_binary_protocol.py
+++ b/glucometerutils/support/lifescan_binary_protocol.py
@@ -16,12 +16,12 @@ from glucometerutils import common
 from glucometerutils.support import construct_extras, lifescan
 
 _LINK_CONTROL = construct.BitStruct(
-    construct.Padding(3),
-    "more" / construct.Default(construct.Flag, False),
-    "disconnect" / construct.Default(construct.Flag, False),
-    "acknowledge" / construct.Default(construct.Flag, False),
-    "expect_receive" / construct.Default(construct.Flag, False),
-    "sequence_number" / construct.Default(construct.Flag, False),
+    padding=construct.Padding(3),
+    more=construct.Default(construct.Flag, False),
+    disconnect=construct.Default(construct.Flag, False),
+    acknowledge=construct.Default(construct.Flag, False),
+    expect_receive=construct.Default(construct.Flag, False),
+    sequence_number=construct.Default(construct.Flag, False),
 )
 
 
@@ -34,19 +34,18 @@ def LifeScanPacket(
         link_control_construct = construct.Const(b"\x00")
 
     return construct.Struct(
-        "data"
-        / construct.RawCopy(
+        data=construct.RawCopy(
             construct.Struct(
-                construct.Const(b"\x02"),  # stx
-                "length"
-                / construct.Rebuild(construct.Byte, lambda this: len(this.message) + 6),
-                "link_control" / link_control_construct,
-                "message" / construct.Bytes(lambda this: this.length - 6),
-                construct.Const(b"\x03"),  # etx
+                stx=construct.Const(b"\x02"),
+                length=construct.Rebuild(
+                    construct.Byte, lambda this: len(this.message) + 6
+                ),
+                link_control=link_control_construct,
+                message=construct.Bytes(lambda this: this.length - 6),
+                etx=construct.Const(b"\x03"),
             ),
         ),
-        "checksum"
-        / construct.Checksum(
+        checksum=construct.Checksum(
             construct.Int16ul, lifescan.crc_ccitt, construct.this.data.data
         ),
     )


### PR DESCRIPTION
Remove usage of overloaded division operator in construct structures.