### PR TITLE
td4277: update dependency information for pyserial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ supported.
 
 ¹ USB only, bluetooth not supported.
 
-² Requires a version of pyserial supporting CP2110 bridges. See [this pyserial
-pull request](https://github.com/pyserial/pyserial/pull/411).
+² Requires a version of pyserial supporting CP2110 bridges. Supported starting
+  from version 3.5.
 
 To identify the supported features for each of the driver, query the `help`
 action:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = {
     "otverio2015": ["construct", "PYSCSI[sgio]>=2.0.1"],
     "otverioiq": ["construct", "pyserial"],
     "sdcodefree": ["construct", "pyserial"],
-    "td4277": ["construct", "pyserial", "hidapi"],
+    "td4277": ["construct", "pyserial[cp2110]>=3.5b0"],
     # These are not drivers, but rather tools and features.
     "reversing_tools": ["usbmon-tools"],
     "dev": [


### PR DESCRIPTION
Now that there's an actual release (even if beta) that supports the CP2110,
we can depend on it with the extras enabled.