### PR TITLE
Pull request for main

### DIFF
--- a/glucometerutils/drivers/fslibre.py
+++ b/glucometerutils/drivers/fslibre.py
@@ -21,6 +21,7 @@ https://protocols.glucometers.tech/abbott/freestyle-libre
 """
 
 import datetime
+import logging
 from typing import Dict, Generator, Mapping, Optional, Sequence, Tuple, Type
 
 from glucometerutils import common
@@ -253,6 +254,7 @@ class Device(freestyle.FreeStyleHidDevice):
         # Then get the results of explicit scans and blood tests (and other
         # events).
         for record in self._session.query_multirecord(b"$arresult?"):
+            logging.debug(f"Retrieved arresult: {record!r}")
             reading = _parse_arresult(record)
             if reading:
                 yield reading

--- a/glucometerutils/drivers/fslibre.py
+++ b/glucometerutils/drivers/fslibre.py
@@ -165,7 +165,7 @@ def _parse_arresult(record: Sequence[str]) -> Optional[common.AnyReading]:
     custom_comments = record[29:35]
     for comment_index in range(6):
         if parsed_record["custom-comments-bitfield"] & (1 << comment_index):
-            comment_parts.append(custom_comments[comment_index][1:-1])
+            comment_parts.append(custom_comments[comment_index])
 
     if parsed_record["sport-flag"]:
         comment_parts.append("Sport")


### PR DESCRIPTION
## fslibre: don't drop the first and last characters of the comment.

The comment string is already parsed out of the quotes (`""`) so there
is no reason to drop the first and last characters, which might make
the comment itself unreadable.

## fslibre: add a debug log for the retrieved arresults.

This just makes debugging a bit easier.