### PR TITLE
Pull request for main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ matrix:
   include:
     - python: 3.7
     - python: 3.8
+    - python: 3.9
       env: PYTEST_OPTIONS="--mypy"
-    - python: 3.9-dev
+    - python: 3.10-dev
 
 install:
   - pip install .[all]

--- a/glucometerutils/drivers/fslibre.py
+++ b/glucometerutils/drivers/fslibre.py
@@ -211,7 +211,7 @@ class Device(freestyle.FreeStyleHidDevice):
     """Glucometer driver for FreeStyle Libre devices."""
 
     def __init__(self, device_path: Optional[str]) -> None:
-        super().__init__(0x3650, device_path)
+        super().__init__(0x3650, device_path, encoding="utf-8")
 
     def get_meter_info(self) -> common.MeterInfo:
         """Return the device information in structured form."""

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ extras_require = {
     # listed as mandatory for the feature.
     "accucheck_reports": [],
     "contourusb": ["construct", "hidapi"],
-    "fsinsulinx": ["freestyle-hid"],
-    "fslibre": ["freestyle-hid"],
+    "fsinsulinx": ["freestyle-hid>=1.0.2"],
+    "fslibre": ["freestyle-hid>=1.0.2"],
     "fsoptium": ["pyserial"],
-    "fsprecisionneo": ["freestyle-hid"],
+    "fsprecisionneo": ["freestyle-hid>=1.0.2"],
     "otultra2": ["pyserial"],
     "otultraeasy": ["construct", "pyserial"],
     "otverio2015": ["construct", "PYSCSI[sgio]>=2.0.1"],


### PR DESCRIPTION
## freestyle: use freestyle-hid 1.0.2 encoding parameter.

This allows FreeStyle Libre devices to use UTF-8 patient names, while
not risking to brick older models that might just support ASCII.

## Travis CI: update matrix of Python versions.