### PR TITLE
Add missing dependency on types-python-dateutil.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
         "pytest-mypy",
         "pytest-timeout>=1.3.0",
         "pytest>=3.6.0",
+        "types-python-dateutil",
     ],
 }
 


### PR DESCRIPTION
It looks like this was split out of typeshed in the meantime.
